### PR TITLE
Add browser-backed protection coordination

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,4 +14,5 @@ _In development._
 - Added the shared theme, six color palettes, bundled Fredoka brand typography, and semantic typography roles.
 - Added build-contract, accessibility, local visual-regression, and cross-browser build checks.
 - Added the local protection-domain foundation for protected sites, schedules, daily wait progression, breathing plans, focus-aware shared waits, wall-clock allowances, warning decisions, metric facts, and restart-safe restoration.
+- Added browser-backed protection restoration with serialized local and session persistence.
 - Added the initial project website, contribution guidance, and public project documentation.

--- a/apps/extension/src/domains/protection/index.ts
+++ b/apps/extension/src/domains/protection/index.ts
@@ -1,2 +1,3 @@
 export * from './types';
 export * from './utils';
+export * from './services';

--- a/apps/extension/src/domains/protection/services/index.ts
+++ b/apps/extension/src/domains/protection/services/index.ts
@@ -1,0 +1,2 @@
+export * from './protection-coordinator';
+export * from './protection-storage';

--- a/apps/extension/src/domains/protection/services/protection-coordinator/index.test.ts
+++ b/apps/extension/src/domains/protection/services/protection-coordinator/index.test.ts
@@ -1,0 +1,835 @@
+import { describe, expect, it } from 'vitest';
+import {
+	createAllowanceExpiry,
+	createDeparture,
+	createFocusChange,
+	createVisitAttempt,
+	TestInstant,
+} from '../../types/__fixtures__/protection-event';
+import {
+	Mock_StoredProtectionParticipant_Navigation,
+	Mock_StoredProtectionState_Durable,
+	Mock_StoredProtectionState_Session,
+} from '../../types/__fixtures__/stored-protection-state';
+import { ProtectionDecisionType } from '../../types/protection-decision';
+import { DepartureCause } from '../../types/protection-event';
+import { ProtectionFactType } from '../../types/protection-fact';
+import {
+	DurableStoredProtectionStateVersion,
+	SessionStoredProtectionStateVersion,
+	StoredDurableProtectionStateSchema,
+	StoredProtectionScopeStateType,
+	StoredProtectionStateSchema,
+	StoredSessionProtectionStateSchema,
+	type StoredProtectionState,
+} from '../../types/stored-protection-state';
+import {
+	createProtectionStorageService,
+	type LoadedProtectionState,
+	type ProtectionStorageArea,
+	type ProtectionStorageService,
+} from '../protection-storage';
+import {
+	ProtectionCoordinatorDispatchStatus,
+	ProtectionCoordinatorFailureReason,
+	ProtectionCoordinatorInitializationStatus,
+	createProtectionCoordinator,
+	type ProtectionCoordinator,
+} from './index';
+
+/**
+ * Promise whose completion is controlled by a test.
+ */
+class DeferredPromise {
+	readonly promise: Promise<void>;
+
+	private resolver: ( () => void ) | null = null;
+
+	/**
+	 * Creates an unresolved promise.
+	 */
+	constructor() {
+		this.promise = new Promise( ( resolve ) => {
+			this.resolver = resolve;
+		} );
+	}
+
+	/**
+	 * Resolves the controlled promise once.
+	 */
+	resolve(): void {
+		this.resolver?.();
+		this.resolver = null;
+	}
+}
+
+/**
+ * In-memory protection storage used to exercise coordinator behavior.
+ */
+class MemoryProtectionStorage implements ProtectionStorageService {
+	readonly savedStates: StoredProtectionState[] = [];
+
+	loadFailure: Error | null = null;
+
+	saveFailure: Error | null = null;
+
+	saveBarrier: Promise<void> | null = null;
+
+	saveStarted: DeferredPromise | null = null;
+
+	/**
+	 * Creates in-memory storage with optional initial documents.
+	 * @param loadedState - Initial durable and session values.
+	 */
+	constructor( private loadedState: LoadedProtectionState = {} ) {}
+
+	/**
+	 * Loads the current in-memory documents.
+	 * @return Loaded documents or a configured rejection.
+	 */
+	load(): Promise<LoadedProtectionState> {
+		return this.loadFailure === null
+			? Promise.resolve( this.loadedState )
+			: Promise.reject( this.loadFailure );
+	}
+
+	/**
+	 * Stores validated documents after any configured barrier.
+	 * @param input - Unknown complete stored-state input.
+	 * @return Promise resolved after the state is stored.
+	 */
+	async save( input: unknown ): Promise<void> {
+		this.saveStarted?.resolve();
+
+		if ( this.saveBarrier !== null ) {
+			await this.saveBarrier;
+		}
+
+		if ( this.saveFailure !== null ) {
+			throw this.saveFailure;
+		}
+
+		const state = StoredProtectionStateSchema.parse( input );
+
+		this.savedStates.push( state );
+		this.loadedState = {
+			durable: state.durable,
+			session: state.session,
+		};
+	}
+}
+
+/**
+ * Independent in-memory browser storage area used for restart recovery tests.
+ */
+class MemoryBrowserStorageArea implements ProtectionStorageArea {
+	writeFailure: Error | null = null;
+
+	/**
+	 * Creates an in-memory browser storage area.
+	 * @param values - Mutable values retained across storage-service instances.
+	 */
+	constructor( private readonly values: Record<string, unknown> = {} ) {}
+
+	/**
+	 * Reads one key from the in-memory area.
+	 * @param key - Requested storage key.
+	 * @return Matching record or an empty record.
+	 */
+	get( key: string ): Promise<Record<string, unknown>> {
+		return Promise.resolve( Object.hasOwn( this.values, key ) ? { [ key ]: this.values[ key ] } : {} );
+	}
+
+	/**
+	 * Writes values unless a failure is configured.
+	 * @param values - Values to retain.
+	 * @return Promise resolved after the values are retained.
+	 */
+	set( values: Record<string, unknown> ): Promise<void> {
+		if ( this.writeFailure !== null ) {
+			return Promise.reject( this.writeFailure );
+		}
+
+		Object.assign( this.values, values );
+
+		return Promise.resolve();
+	}
+}
+
+const DURABLE_ALLOWANCE = StoredDurableProtectionStateSchema.parse( {
+	schemaVersion: DurableStoredProtectionStateVersion,
+	scopes: {
+		'scope-a': {
+			ladder: {
+				completedWaits: 2,
+				greatestObservedLocalDate: '2026-08-31',
+			},
+			allowance: {
+				allowanceId: 'allowance-a',
+				startedAtEpochMilliseconds: TestInstant - 1_000,
+				expiresAtEpochMilliseconds: TestInstant + 299_000,
+			},
+		},
+	},
+} );
+
+const SESSION_WAITING = StoredSessionProtectionStateSchema.parse( {
+	schemaVersion: SessionStoredProtectionStateVersion,
+	sessionContinuityId: 'session-current',
+	scopes: {
+		'scope-a': {
+			type: StoredProtectionScopeStateType.WAITING,
+			waitId: 'wait-a',
+			capturedWaitDurationMilliseconds: 10_000,
+			confirmedFocusedDurationMilliseconds: 2_000,
+			participants: [ Mock_StoredProtectionParticipant_Navigation ],
+			ownerParticipantId: 'participant-a',
+			ownerEpoch: 1,
+			checkpointHighWaterMilliseconds: 2_000,
+		},
+	},
+} );
+
+/**
+ * Supplies a deterministic new-session continuity identifier.
+ * @return Stable continuity identifier.
+ */
+function createTestSessionContinuityId(): string {
+	return 'session-new';
+}
+
+/**
+ * Creates a deterministic sequence of valid storage snapshot identifiers.
+ * @param initialSequence - Sequence value before the first identifier.
+ * @return Snapshot identifier factory.
+ */
+function createSnapshotIdSequence( initialSequence = 0 ): () => string {
+	let sequence = initialSequence;
+
+	return () => {
+		sequence += 1;
+
+		return `00000000-0000-4000-8000-${ String( sequence ).padStart( 12, '0' ) }`;
+	};
+}
+
+/**
+ * Creates a coordinator with deterministic test dependencies.
+ * @param storage - In-memory protection storage.
+ * @param sessionContinuityId - New-session continuity identifier.
+ * @return Protection coordinator under test.
+ */
+function createTestCoordinator(
+	storage: ProtectionStorageService,
+	sessionContinuityId = createTestSessionContinuityId(),
+): ProtectionCoordinator {
+	/**
+	 * Supplies this coordinator's deterministic continuity identifier.
+	 * @return Stable continuity identifier.
+	 */
+	function createSessionContinuityId(): string {
+		return sessionContinuityId;
+	}
+
+	return createProtectionCoordinator( {
+		storage,
+		createSessionContinuityId,
+	} );
+}
+
+/**
+ * Returns the most recently persisted complete state.
+ * @param storage - In-memory protection storage.
+ * @return Latest persisted state.
+ */
+function getLatestSavedState( storage: MemoryProtectionStorage ): StoredProtectionState {
+	const state = storage.savedStates.at( -1 );
+
+	if ( state === undefined ) {
+		throw new Error( 'Expected protection state to be persisted.' );
+	}
+
+	return state;
+}
+
+describe( 'protection coordinator initialization', () => {
+	it( 'creates and persists a continuity identifier for empty storage', async () => {
+		const storage = new MemoryProtectionStorage();
+		const coordinator = createTestCoordinator( storage );
+
+		await expect( coordinator.initialize( {
+			nowEpochMilliseconds: TestInstant,
+			readyObservations: [],
+		} ) ).resolves.toEqual( {
+			status: ProtectionCoordinatorInitializationStatus.READY,
+			decisions: [],
+			facts: [],
+			requirements: [],
+		} );
+		expect( getLatestSavedState( storage ).session.sessionContinuityId ).toBe( 'session-new' );
+	} );
+
+	it( 'reuses a valid continued-session continuity identifier', async () => {
+		const storage = new MemoryProtectionStorage( {
+			durable: Mock_StoredProtectionState_Durable,
+			session: Mock_StoredProtectionState_Session,
+		} );
+		const coordinator = createTestCoordinator( storage );
+
+		const result = await coordinator.initialize( {
+			nowEpochMilliseconds: TestInstant,
+			readyObservations: [],
+		} );
+
+		expect( result.status ).toBe( ProtectionCoordinatorInitializationStatus.READY );
+		expect( getLatestSavedState( storage ).session.sessionContinuityId ).toBe( 'session-current' );
+	} );
+
+	it( 'restores a continued wait without focus ownership or lost progress', async () => {
+		const storage = new MemoryProtectionStorage( {
+			durable: Mock_StoredProtectionState_Durable,
+			session: SESSION_WAITING,
+		} );
+		const coordinator = createTestCoordinator( storage );
+
+		const result = await coordinator.initialize( {
+			nowEpochMilliseconds: TestInstant,
+			readyObservations: [],
+		} );
+		const storedWaiting = getLatestSavedState( storage ).session.scopes[ 'scope-a' ];
+
+		expect( result.status ).toBe( ProtectionCoordinatorInitializationStatus.READY );
+		expect( storedWaiting ).toMatchObject( {
+			type: StoredProtectionScopeStateType.WAITING,
+			confirmedFocusedDurationMilliseconds: 2_000,
+			ownerParticipantId: null,
+			ownerEpoch: 2,
+			checkpointHighWaterMilliseconds: 0,
+		} );
+	} );
+
+	it( 'starts a new session after corrupt session state without losing durable state', async () => {
+		const storage = new MemoryProtectionStorage( {
+			durable: Mock_StoredProtectionState_Durable,
+			session: { schemaVersion: 1, scopes: 'invalid' },
+		} );
+		const coordinator = createTestCoordinator( storage );
+
+		const result = await coordinator.initialize( {
+			nowEpochMilliseconds: TestInstant,
+			readyObservations: [],
+		} );
+		const savedState = getLatestSavedState( storage );
+
+		expect( result.status ).toBe( ProtectionCoordinatorInitializationStatus.READY );
+		expect( savedState.durable ).toEqual( Mock_StoredProtectionState_Durable );
+		expect( savedState.session.sessionContinuityId ).toBe( 'session-new' );
+	} );
+
+	it( 'does not overwrite corrupt durable state', async () => {
+		const storage = new MemoryProtectionStorage( {
+			durable: {
+				schemaVersion: DurableStoredProtectionStateVersion,
+				scopes: {
+					'scope-a': {
+						ladder: {
+							completedWaits: -1,
+							greatestObservedLocalDate: '2026-08-31',
+						},
+					},
+				},
+			},
+		} );
+		const coordinator = createTestCoordinator( storage );
+
+		await expect( coordinator.initialize( {
+			nowEpochMilliseconds: TestInstant,
+			readyObservations: [],
+		} ) ).resolves.toEqual( {
+			status: ProtectionCoordinatorInitializationStatus.FAILED,
+			reason: ProtectionCoordinatorFailureReason.INVALID_DURABLE_STATE,
+			decisions: [],
+			facts: [],
+			requirements: [],
+		} );
+		expect( storage.savedStates ).toEqual( [] );
+	} );
+
+	it( 'restores an unexpired durable allowance in a new session', async () => {
+		const storage = new MemoryProtectionStorage( { durable: DURABLE_ALLOWANCE } );
+		const coordinator = createTestCoordinator( storage );
+
+		const result = await coordinator.initialize( {
+			nowEpochMilliseconds: TestInstant,
+			readyObservations: [],
+		} );
+
+		expect( result.status ).toBe( ProtectionCoordinatorInitializationStatus.READY );
+		expect( getLatestSavedState( storage ).durable ).toEqual( DURABLE_ALLOWANCE );
+	} );
+
+	it( 'returns unresolved Ready reconciliation requirements', async () => {
+		const storage = new MemoryProtectionStorage( {
+			durable: DURABLE_ALLOWANCE,
+			session: Mock_StoredProtectionState_Session,
+		} );
+		const coordinator = createTestCoordinator( storage );
+
+		const result = await coordinator.initialize( {
+			nowEpochMilliseconds: TestInstant,
+			readyObservations: [],
+		} );
+
+		expect( result.status ).toBe( ProtectionCoordinatorInitializationStatus.RECONCILIATION_REQUIRED );
+		expect( result.requirements ).toEqual( [ {
+			scopeId: 'scope-a',
+			allowanceId: 'allowance-a',
+			participantId: 'participant-a',
+			pageId: 'page-a',
+			reason: 'observation-unavailable',
+		} ] );
+	} );
+
+	it( 'reports a storage read failure without persisting state', async () => {
+		const storage = new MemoryProtectionStorage();
+		const readFailure = new Error( 'read failed' );
+
+		storage.loadFailure = readFailure;
+
+		const result = await createTestCoordinator( storage ).initialize( {
+			nowEpochMilliseconds: TestInstant,
+			readyObservations: [],
+		} );
+
+		expect( result ).toEqual( {
+			status: ProtectionCoordinatorInitializationStatus.FAILED,
+			reason: ProtectionCoordinatorFailureReason.STORAGE_READ_FAILED,
+			decisions: [],
+			facts: [],
+			requirements: [],
+		} );
+		expect( storage.savedStates ).toEqual( [] );
+	} );
+
+	it( 'reports a storage write failure without becoming initialized', async () => {
+		const storage = new MemoryProtectionStorage();
+
+		storage.saveFailure = new Error( 'write failed' );
+
+		const coordinator = createTestCoordinator( storage );
+		const initialization = await coordinator.initialize( {
+			nowEpochMilliseconds: TestInstant,
+			readyObservations: [],
+		} );
+		const dispatch = await coordinator.dispatch( () => createVisitAttempt() );
+
+		expect( initialization ).toEqual( {
+			status: ProtectionCoordinatorInitializationStatus.FAILED,
+			reason: ProtectionCoordinatorFailureReason.STORAGE_WRITE_FAILED,
+			decisions: [],
+			facts: [],
+			requirements: [],
+		} );
+		expect( dispatch ).toEqual( {
+			status: ProtectionCoordinatorDispatchStatus.REJECTED,
+			reason: ProtectionCoordinatorFailureReason.NOT_INITIALIZED,
+			decisions: [],
+			facts: [],
+		} );
+	} );
+
+	it( 'does not expose restored state before persistence completes', async () => {
+		const storage = new MemoryProtectionStorage();
+		const saveStarted = new DeferredPromise();
+		const saveBarrier = new DeferredPromise();
+
+		storage.saveStarted = saveStarted;
+		storage.saveBarrier = saveBarrier.promise;
+
+		const initialization = createTestCoordinator( storage ).initialize( {
+			nowEpochMilliseconds: TestInstant,
+			readyObservations: [],
+		} );
+		let settled = false;
+
+		void initialization.then( () => {
+			settled = true;
+		} );
+		await saveStarted.promise;
+
+		expect( settled ).toBe( false );
+		expect( storage.savedStates ).toEqual( [] );
+
+		saveBarrier.resolve();
+
+		await expect( initialization ).resolves.toMatchObject( {
+			status: ProtectionCoordinatorInitializationStatus.READY,
+		} );
+	} );
+
+	it( 'serializes dispatch behind initialization persistence', async () => {
+		const storage = new MemoryProtectionStorage();
+		const saveStarted = new DeferredPromise();
+		const saveBarrier = new DeferredPromise();
+		const coordinator = createTestCoordinator( storage );
+		let eventPrepared = false;
+
+		storage.saveStarted = saveStarted;
+		storage.saveBarrier = saveBarrier.promise;
+
+		const initialization = coordinator.initialize( {
+			nowEpochMilliseconds: TestInstant,
+			readyObservations: [],
+		} );
+		const dispatch = coordinator.dispatch( () => {
+			eventPrepared = true;
+			return createVisitAttempt();
+		} );
+
+		await saveStarted.promise;
+
+		expect( eventPrepared ).toBe( false );
+
+		saveBarrier.resolve();
+
+		await expect( initialization ).resolves.toMatchObject( {
+			status: ProtectionCoordinatorInitializationStatus.READY,
+		} );
+		await expect( dispatch ).resolves.toMatchObject( {
+			status: ProtectionCoordinatorDispatchStatus.APPLIED,
+		} );
+	} );
+} );
+
+describe( 'protection coordinator dispatch', () => {
+	it( 'rejects dispatch before successful initialization', async () => {
+		const result = await createTestCoordinator( new MemoryProtectionStorage() ).dispatch(
+			() => createVisitAttempt(),
+		);
+
+		expect( result ).toEqual( {
+			status: ProtectionCoordinatorDispatchStatus.REJECTED,
+			reason: ProtectionCoordinatorFailureReason.NOT_INITIALIZED,
+			decisions: [],
+			facts: [],
+		} );
+	} );
+
+	it( 'rejects invalid events with a typed empty-effects result', async () => {
+		const storage = new MemoryProtectionStorage();
+		const coordinator = createTestCoordinator( storage );
+
+		await coordinator.initialize( { nowEpochMilliseconds: TestInstant, readyObservations: [] } );
+
+		await expect( coordinator.dispatch( () => ( { type: 'invalid' } ) ) ).resolves.toEqual( {
+			status: ProtectionCoordinatorDispatchStatus.REJECTED,
+			reason: ProtectionCoordinatorFailureReason.INVALID_EVENT,
+			decisions: [],
+			facts: [],
+		} );
+	} );
+
+	it( 'continues serializing after event preparation rejects', async () => {
+		const storage = new MemoryProtectionStorage();
+		const coordinator = createTestCoordinator( storage );
+		const preparationFailure = new Error( 'preparation failed' );
+
+		await coordinator.initialize( { nowEpochMilliseconds: TestInstant, readyObservations: [] } );
+		await expect( coordinator.dispatch( () => Promise.reject( preparationFailure ) ) ).rejects.toBe(
+			preparationFailure,
+		);
+		await expect( coordinator.dispatch( () => createVisitAttempt() ) ).resolves.toMatchObject( {
+			status: ProtectionCoordinatorDispatchStatus.APPLIED,
+		} );
+	} );
+
+	it( 'creates the minimum Idle scope for a first visit attempt', async () => {
+		const storage = new MemoryProtectionStorage();
+		const coordinator = createTestCoordinator( storage );
+
+		await coordinator.initialize( { nowEpochMilliseconds: TestInstant, readyObservations: [] } );
+
+		const result = await coordinator.dispatch( () => createVisitAttempt() );
+		const storedWaiting = getLatestSavedState( storage ).session.scopes[ 'scope-default' ];
+
+		expect( result.status ).toBe( ProtectionCoordinatorDispatchStatus.APPLIED );
+		expect( result.decisions ).toMatchObject( [ { type: ProtectionDecisionType.PRESENT_WAITING } ] );
+		expect( storedWaiting ).toMatchObject( {
+			type: StoredProtectionScopeStateType.WAITING,
+			waitId: 'wait-a',
+			participants: [ { participantId: 'participant-a', pageId: 'page-a' } ],
+		} );
+		expect( getLatestSavedState( storage ).durable.scopes[ 'scope-default' ]?.ladder ).toEqual( {
+			completedWaits: 0,
+			greatestObservedLocalDate: '2026-08-31',
+		} );
+	} );
+
+	it.each( [ 'toString', 'constructor', 'hasOwnProperty', '__proto__' ] )(
+		'creates a first-visit scope for the prototype key %s',
+		async ( scopeId ) => {
+			const storage = new MemoryProtectionStorage();
+			const coordinator = createTestCoordinator( storage );
+
+			await coordinator.initialize( { nowEpochMilliseconds: TestInstant, readyObservations: [] } );
+
+			const result = await coordinator.dispatch( () => createVisitAttempt(
+				'participant-a',
+				'page-a',
+				true,
+				{ scopeId },
+			) );
+
+			expect( result.status ).toBe( ProtectionCoordinatorDispatchStatus.APPLIED );
+			expect( getLatestSavedState( storage ).session.scopes[ scopeId ] ).toMatchObject( {
+				type: StoredProtectionScopeStateType.WAITING,
+			} );
+		},
+	);
+
+	it( 'rejects a non-visit event for an unknown scope without writing', async () => {
+		const storage = new MemoryProtectionStorage();
+		const coordinator = createTestCoordinator( storage );
+
+		await coordinator.initialize( { nowEpochMilliseconds: TestInstant, readyObservations: [] } );
+
+		const savedStateCount = storage.savedStates.length;
+		const result = await coordinator.dispatch( () => createFocusChange(
+			'participant-a',
+			false,
+			1,
+			{ scopeId: 'scope-unknown' },
+		) );
+
+		expect( result ).toEqual( {
+			status: ProtectionCoordinatorDispatchStatus.REJECTED,
+			reason: ProtectionCoordinatorFailureReason.UNKNOWN_SCOPE,
+			decisions: [],
+			facts: [],
+		} );
+		expect( storage.savedStates ).toHaveLength( savedStateCount );
+	} );
+
+	it.each( [ 'toString', 'constructor', 'hasOwnProperty', '__proto__' ] )(
+		'rejects a non-visit event for the unknown prototype key %s',
+		async ( scopeId ) => {
+			const storage = new MemoryProtectionStorage();
+			const coordinator = createTestCoordinator( storage );
+
+			await coordinator.initialize( { nowEpochMilliseconds: TestInstant, readyObservations: [] } );
+
+			const savedStateCount = storage.savedStates.length;
+			const result = await coordinator.dispatch( () => createFocusChange(
+				'participant-a',
+				false,
+				1,
+				{ scopeId },
+			) );
+
+			expect( result ).toEqual( {
+				status: ProtectionCoordinatorDispatchStatus.REJECTED,
+				reason: ProtectionCoordinatorFailureReason.UNKNOWN_SCOPE,
+				decisions: [],
+				facts: [],
+			} );
+			expect( storage.savedStates ).toHaveLength( savedStateCount );
+		},
+	);
+
+	it( 'does not expose transition effects before persistence completes', async () => {
+		const storage = new MemoryProtectionStorage();
+		const coordinator = createTestCoordinator( storage );
+
+		await coordinator.initialize( { nowEpochMilliseconds: TestInstant, readyObservations: [] } );
+
+		const saveStarted = new DeferredPromise();
+		const saveBarrier = new DeferredPromise();
+
+		storage.saveStarted = saveStarted;
+		storage.saveBarrier = saveBarrier.promise;
+
+		const dispatch = coordinator.dispatch( () => createVisitAttempt() );
+		let settled = false;
+
+		void dispatch.then( () => {
+			settled = true;
+		} );
+		await saveStarted.promise;
+
+		expect( settled ).toBe( false );
+
+		saveBarrier.resolve();
+
+		await expect( dispatch ).resolves.toMatchObject( {
+			status: ProtectionCoordinatorDispatchStatus.APPLIED,
+		} );
+	} );
+
+	it( 'returns no unpersisted effects and retains the last confirmed state after write failure', async () => {
+		const storage = new MemoryProtectionStorage();
+		const coordinator = createTestCoordinator( storage );
+
+		await coordinator.initialize( { nowEpochMilliseconds: TestInstant, readyObservations: [] } );
+
+		storage.saveFailure = new Error( 'write failed' );
+
+		const failed = await coordinator.dispatch( () => createVisitAttempt() );
+
+		expect( failed ).toEqual( {
+			status: ProtectionCoordinatorDispatchStatus.REJECTED,
+			reason: ProtectionCoordinatorFailureReason.STORAGE_WRITE_FAILED,
+			decisions: [],
+			facts: [],
+		} );
+
+		storage.saveFailure = null;
+
+		const applied = await coordinator.dispatch( () => createVisitAttempt( 'participant-b', 'page-b' ) );
+		const storedWaiting = getLatestSavedState( storage ).session.scopes[ 'scope-default' ];
+
+		expect( applied.status ).toBe( ProtectionCoordinatorDispatchStatus.APPLIED );
+		expect( storedWaiting ).toMatchObject( {
+			participants: [ { participantId: 'participant-b', pageId: 'page-b' } ],
+		} );
+	} );
+
+	it( 'does not recover a session-only partial write after a worker restart', async () => {
+		const durableArea = new MemoryBrowserStorageArea();
+		const sessionArea = new MemoryBrowserStorageArea();
+		const initialStorage = createProtectionStorageService( {
+			durableArea,
+			sessionArea,
+			createSnapshotId: createSnapshotIdSequence(),
+		} );
+		const initialCoordinator = createTestCoordinator( initialStorage, 'session-initial' );
+
+		await initialCoordinator.initialize( {
+			nowEpochMilliseconds: TestInstant,
+			readyObservations: [],
+		} );
+
+		durableArea.writeFailure = new Error( 'durable write failed' );
+
+		await expect( initialCoordinator.dispatch( () => createVisitAttempt() ) ).resolves.toEqual( {
+			status: ProtectionCoordinatorDispatchStatus.REJECTED,
+			reason: ProtectionCoordinatorFailureReason.STORAGE_WRITE_FAILED,
+			decisions: [],
+			facts: [],
+		} );
+
+		durableArea.writeFailure = null;
+
+		const recoveredStorage = createProtectionStorageService( {
+			durableArea,
+			sessionArea,
+			createSnapshotId: createSnapshotIdSequence( 100 ),
+		} );
+		const recoveredCoordinator = createTestCoordinator( recoveredStorage, 'session-recovered' );
+
+		await expect( recoveredCoordinator.initialize( {
+			nowEpochMilliseconds: TestInstant,
+			readyObservations: [],
+		} ) ).resolves.toMatchObject( {
+			status: ProtectionCoordinatorInitializationStatus.READY,
+		} );
+
+		const recoveredState = StoredProtectionStateSchema.parse( await recoveredStorage.load() );
+
+		expect( recoveredState.session.sessionContinuityId ).toBe( 'session-recovered' );
+		expect( recoveredState.session.scopes ).toEqual( {} );
+	} );
+
+	it( 'serializes concurrent same-scope visits without losing a participant', async () => {
+		const storage = new MemoryProtectionStorage();
+		const coordinator = createTestCoordinator( storage );
+
+		await coordinator.initialize( { nowEpochMilliseconds: TestInstant, readyObservations: [] } );
+
+		const saveStarted = new DeferredPromise();
+		const saveBarrier = new DeferredPromise();
+
+		storage.saveStarted = saveStarted;
+		storage.saveBarrier = saveBarrier.promise;
+
+		const first = coordinator.dispatch( () => createVisitAttempt() );
+		const second = coordinator.dispatch( () => createVisitAttempt( 'participant-b', 'page-b' ) );
+
+		await saveStarted.promise;
+		saveBarrier.resolve();
+
+		await expect( Promise.all( [ first, second ] ) ).resolves.toMatchObject( [
+			{ status: ProtectionCoordinatorDispatchStatus.APPLIED },
+			{ status: ProtectionCoordinatorDispatchStatus.APPLIED },
+		] );
+
+		const storedWaiting = getLatestSavedState( storage ).session.scopes[ 'scope-default' ];
+
+		expect( storedWaiting ).toMatchObject( {
+			participants: [
+				{ participantId: 'participant-a', pageId: 'page-a' },
+				{ participantId: 'participant-b', pageId: 'page-b' },
+			],
+		} );
+	} );
+
+	it( 'preserves domain idempotence when a departure is replayed', async () => {
+		const storage = new MemoryProtectionStorage();
+		const coordinator = createTestCoordinator( storage );
+
+		await coordinator.initialize( { nowEpochMilliseconds: TestInstant, readyObservations: [] } );
+		await coordinator.dispatch( () => createVisitAttempt() );
+
+		const departure = createDeparture( DepartureCause.ACTIVE_SESSION_TAB_CLOSE );
+		const first = await coordinator.dispatch( () => departure );
+		const replay = await coordinator.dispatch( () => departure );
+
+		expect( first.facts ).toMatchObject( [ { type: ProtectionFactType.RECONSIDERED_VISIT } ] );
+		expect( replay.facts ).toEqual( [] );
+	} );
+
+	it( 'holds allowance-expiry candidate collection inside the shared queue', async () => {
+		const storage = new MemoryProtectionStorage( { durable: DURABLE_ALLOWANCE } );
+		const coordinator = createTestCoordinator( storage );
+		const preparationStarted = new DeferredPromise();
+		const preparationBarrier = new DeferredPromise();
+		const preparationOrder: string[] = [];
+
+		await coordinator.initialize( { nowEpochMilliseconds: TestInstant, readyObservations: [] } );
+
+		const expiry = coordinator.dispatch( async () => {
+			preparationOrder.push( 'expiry-started' );
+			preparationStarted.resolve();
+			await preparationBarrier.promise;
+			preparationOrder.push( 'expiry-completed' );
+
+			return createAllowanceExpiry( [], undefined, { scopeId: 'scope-a' } );
+		} );
+
+		await preparationStarted.promise;
+
+		const visit = coordinator.dispatch( () => {
+			preparationOrder.push( 'visit-prepared' );
+
+			return createVisitAttempt(
+				'participant-b',
+				'page-b',
+				true,
+				{ scopeId: 'scope-a', waitId: 'wait-after-expiry' },
+			);
+		} );
+
+		expect( preparationOrder ).toEqual( [ 'expiry-started' ] );
+
+		preparationBarrier.resolve();
+
+		await expect( Promise.all( [ expiry, visit ] ) ).resolves.toMatchObject( [
+			{ status: ProtectionCoordinatorDispatchStatus.APPLIED },
+			{ status: ProtectionCoordinatorDispatchStatus.APPLIED },
+		] );
+		expect( preparationOrder ).toEqual( [
+			'expiry-started',
+			'expiry-completed',
+			'visit-prepared',
+		] );
+	} );
+} );

--- a/apps/extension/src/domains/protection/services/protection-coordinator/index.ts
+++ b/apps/extension/src/domains/protection/services/protection-coordinator/index.ts
@@ -1,0 +1,260 @@
+import {
+	ProtectionEventSchema,
+	ProtectionEventType,
+} from '../../types/protection-event';
+import {
+	ProtectionStateSchema,
+	ProtectionStateType,
+	type ProtectionState,
+} from '../../types/protection-state';
+import { SessionContinuityIdSchema } from '../../types/protection-value';
+import {
+	StoredProtectionStateParseStatus,
+	parseStoredProtectionState,
+} from '../../utils/parse-stored-protection-state';
+import { prepareStoredProtectionState } from '../../utils/prepare-stored-protection-state';
+import {
+	ProtectionStateRestoreMode,
+	ProtectionStateRestoreStatus,
+	restoreProtectionState,
+} from '../../utils/restore-protection-state';
+import { transitionProtectionState } from '../../utils/transition-protection-state';
+import {
+	ProtectionCoordinatorDispatchResultSchema,
+	ProtectionCoordinatorDispatchStatus,
+	ProtectionCoordinatorFailureReason,
+	ProtectionCoordinatorInitializationInputSchema,
+	ProtectionCoordinatorInitializationResultSchema,
+	ProtectionCoordinatorInitializationStatus,
+	type ProtectionCoordinator,
+	type ProtectionCoordinatorDispatchResult,
+	type ProtectionCoordinatorFailureReason as ProtectionCoordinatorFailureReasonValue,
+	type ProtectionCoordinatorInitializationResult,
+	type ProtectionCoordinatorOptions,
+	type PrepareProtectionEvent,
+} from './types';
+
+/**
+ * Creates a validated failed initialization result without exposing an error object.
+ * @param reason - Stable initialization failure reason.
+ * @return Failed initialization result.
+ * @since 0.1.0 Initial implementation.
+ */
+function createInitializationFailure(
+	reason: ProtectionCoordinatorFailureReasonValue,
+): ProtectionCoordinatorInitializationResult {
+	return ProtectionCoordinatorInitializationResultSchema.parse( {
+		status: ProtectionCoordinatorInitializationStatus.FAILED,
+		reason,
+		decisions: [],
+		facts: [],
+		requirements: [],
+	} );
+}
+
+/**
+ * Creates a validated rejected dispatch result without unpersisted effects.
+ * @param reason - Stable dispatch rejection reason.
+ * @return Rejected dispatch result.
+ * @since 0.1.0 Initial implementation.
+ */
+function createDispatchRejection(
+	reason: ProtectionCoordinatorFailureReasonValue,
+): ProtectionCoordinatorDispatchResult {
+	return ProtectionCoordinatorDispatchResultSchema.parse( {
+		status: ProtectionCoordinatorDispatchStatus.REJECTED,
+		reason,
+		decisions: [],
+		facts: [],
+	} );
+}
+
+/**
+ * Creates one serialized protection runtime coordinator.
+ * @param options - Storage and identifier dependencies.
+ * @return Protection coordinator instance.
+ * @since 0.1.0 Initial implementation.
+ */
+export function createProtectionCoordinator( options: ProtectionCoordinatorOptions ): ProtectionCoordinator {
+	let statesByScope: Record<string, ProtectionState> | null = null;
+	let sessionContinuityId: string | null = null;
+	let operationQueue: Promise<void> = Promise.resolve();
+
+	/**
+	 * Serializes one coordinator operation without poisoning the queue after rejection.
+	 * @param operation - Deferred coordinator operation.
+	 * @return Promise for the operation result.
+	 * @since 0.1.0 Initial implementation.
+	 */
+	function enqueue<T>( operation: () => Promise<T> ): Promise<T> {
+		const result = operationQueue.then( operation, operation );
+
+		operationQueue = result.then(
+			() => undefined,
+			() => undefined,
+		);
+
+		return result;
+	}
+
+	/**
+	 * Restores, normalizes, and persists protection state inside the serialized queue.
+	 * @param input - Unknown initialization observations.
+	 * @return Validated initialization result after persistence.
+	 * @throws {Error} When input validation or a domain invariant fails unexpectedly.
+	 * @since 0.1.0 Initial implementation.
+	 */
+	async function initializeOperation( input: unknown ): Promise<ProtectionCoordinatorInitializationResult> {
+		const parsedInput = ProtectionCoordinatorInitializationInputSchema.parse( input );
+		let loadedState: Awaited<ReturnType<typeof options.storage.load>>;
+
+		try {
+			loadedState = await options.storage.load();
+		} catch {
+			return createInitializationFailure( ProtectionCoordinatorFailureReason.STORAGE_READ_FAILED );
+		}
+
+		const parsedState = parseStoredProtectionState( loadedState );
+		const nextSessionContinuityId = SessionContinuityIdSchema.parse(
+			parsedState.session.status === StoredProtectionStateParseStatus.CURRENT
+				? parsedState.session.state.sessionContinuityId
+				: options.createSessionContinuityId(),
+		);
+		const restoredState = restoreProtectionState(
+			parsedState.session.status === StoredProtectionStateParseStatus.CURRENT
+				? {
+					mode: ProtectionStateRestoreMode.CONTINUED_SESSION,
+					parsedState,
+					nowEpochMilliseconds: parsedInput.nowEpochMilliseconds,
+					sessionContinuityId: nextSessionContinuityId,
+					readyObservations: parsedInput.readyObservations,
+				}
+				: {
+					mode: ProtectionStateRestoreMode.NEW_SESSION,
+					parsedState,
+					nowEpochMilliseconds: parsedInput.nowEpochMilliseconds,
+				},
+		);
+
+		if ( restoredState.status === ProtectionStateRestoreStatus.FAILURE ) {
+			return createInitializationFailure( ProtectionCoordinatorFailureReason.INVALID_DURABLE_STATE );
+		}
+
+		const preparedState = prepareStoredProtectionState( {
+			statesByScope: restoredState.statesByScope,
+			sessionContinuityId: nextSessionContinuityId,
+		} );
+
+		try {
+			await options.storage.save( preparedState );
+		} catch {
+			return createInitializationFailure( ProtectionCoordinatorFailureReason.STORAGE_WRITE_FAILED );
+		}
+
+		statesByScope = restoredState.statesByScope;
+		sessionContinuityId = nextSessionContinuityId;
+
+		return ProtectionCoordinatorInitializationResultSchema.parse( {
+			status: restoredState.status === ProtectionStateRestoreStatus.RECONCILIATION_REQUIRED
+				? ProtectionCoordinatorInitializationStatus.RECONCILIATION_REQUIRED
+				: ProtectionCoordinatorInitializationStatus.READY,
+			decisions: restoredState.decisions,
+			facts: [],
+			requirements: restoredState.requirements,
+		} );
+	}
+
+	/**
+	 * Prepares, applies, and persists one protection event inside the serialized queue.
+	 * @param prepareEvent - Deferred event preparation with current browser observations.
+	 * @return Validated dispatch result after persistence.
+	 * @throws {Error} When event preparation rejects or a domain invariant fails unexpectedly.
+	 * @since 0.1.0 Initial implementation.
+	 */
+	async function dispatchOperation(
+		prepareEvent: PrepareProtectionEvent,
+	): Promise<ProtectionCoordinatorDispatchResult> {
+		const currentStatesByScope = statesByScope;
+		const currentSessionContinuityId = sessionContinuityId;
+
+		if ( currentStatesByScope === null || currentSessionContinuityId === null ) {
+			return createDispatchRejection( ProtectionCoordinatorFailureReason.NOT_INITIALIZED );
+		}
+
+		const eventResult = ProtectionEventSchema.safeParse( await prepareEvent() );
+
+		if ( ! eventResult.success ) {
+			return createDispatchRejection( ProtectionCoordinatorFailureReason.INVALID_EVENT );
+		}
+
+		const parsedEvent = eventResult.data;
+		let currentState = Object.hasOwn( currentStatesByScope, parsedEvent.scopeId )
+			? currentStatesByScope[ parsedEvent.scopeId ]
+			: undefined;
+
+		if ( currentState === undefined ) {
+			if ( parsedEvent.type !== ProtectionEventType.VISIT_ATTEMPT ) {
+				return createDispatchRejection( ProtectionCoordinatorFailureReason.UNKNOWN_SCOPE );
+			}
+
+			currentState = ProtectionStateSchema.parse( {
+				type: ProtectionStateType.IDLE,
+				scopeId: parsedEvent.scopeId,
+				ladder: {
+					completedWaits: 0,
+					greatestObservedLocalDate: parsedEvent.observedLocalDate,
+				},
+			} );
+		}
+
+		const transition = transitionProtectionState( currentState, parsedEvent );
+		const nextStatesByScope = {
+			...currentStatesByScope,
+			[ parsedEvent.scopeId ]: transition.state,
+		};
+		const preparedState = prepareStoredProtectionState( {
+			statesByScope: nextStatesByScope,
+			sessionContinuityId: currentSessionContinuityId,
+		} );
+
+		try {
+			await options.storage.save( preparedState );
+		} catch {
+			return createDispatchRejection( ProtectionCoordinatorFailureReason.STORAGE_WRITE_FAILED );
+		}
+
+		statesByScope = nextStatesByScope;
+
+		return ProtectionCoordinatorDispatchResultSchema.parse( {
+			status: ProtectionCoordinatorDispatchStatus.APPLIED,
+			decisions: transition.decisions,
+			facts: transition.facts,
+		} );
+	}
+
+	/**
+	 * Enqueues protection-state initialization.
+	 * @param input - Unknown initialization observations.
+	 * @return Validated initialization result after persistence.
+	 * @throws {Error} When input validation or a domain invariant fails unexpectedly.
+	 * @since 0.1.0 Initial implementation.
+	 */
+	function initialize( input: unknown ): Promise<ProtectionCoordinatorInitializationResult> {
+		return enqueue( () => initializeOperation( input ) );
+	}
+
+	/**
+	 * Enqueues deferred preparation for one protection event.
+	 * @param prepareEvent - Deferred event preparation with current browser observations.
+	 * @return Validated dispatch result after persistence.
+	 * @throws {Error} When event preparation rejects or a domain invariant fails unexpectedly.
+	 * @since 0.1.0 Initial implementation.
+	 */
+	function dispatch( prepareEvent: PrepareProtectionEvent ): Promise<ProtectionCoordinatorDispatchResult> {
+		return enqueue( () => dispatchOperation( prepareEvent ) );
+	}
+
+	return { initialize, dispatch };
+}
+
+export * from './types';

--- a/apps/extension/src/domains/protection/services/protection-coordinator/types.ts
+++ b/apps/extension/src/domains/protection/services/protection-coordinator/types.ts
@@ -1,0 +1,247 @@
+import { z } from 'zod';
+import { ProtectionDecisionSchema } from '../../types/protection-decision';
+import { ProtectionFactSchema } from '../../types/protection-fact';
+import { EpochMillisecondsSchema } from '../../types/protection-value';
+import {
+	ProtectionStateReconciliationRequirementSchema,
+	ReadyProtectionStateRestoreObservationSchema,
+} from '../../utils/restore-protection-state';
+import { type ProtectionStorageService } from '../protection-storage';
+
+/**
+ * Outcomes of protection coordinator initialization.
+ * @since 0.1.0 Initial implementation.
+ */
+export const ProtectionCoordinatorInitializationStatus = {
+	READY: 'ready',
+	RECONCILIATION_REQUIRED: 'reconciliation-required',
+	FAILED: 'failed',
+} as const;
+
+/**
+ * Validates a protection coordinator initialization outcome.
+ * @since 0.1.0 Initial implementation.
+ */
+export const ProtectionCoordinatorInitializationStatusSchema = z.enum(
+	ProtectionCoordinatorInitializationStatus,
+);
+
+/**
+ * Protection coordinator initialization outcome.
+ * @since 0.1.0 Initial implementation.
+ */
+export type ProtectionCoordinatorInitializationStatus = z.infer<
+	typeof ProtectionCoordinatorInitializationStatusSchema
+>;
+
+/**
+ * Outcomes of one protection coordinator dispatch.
+ * @since 0.1.0 Initial implementation.
+ */
+export const ProtectionCoordinatorDispatchStatus = {
+	APPLIED: 'applied',
+	REJECTED: 'rejected',
+} as const;
+
+/**
+ * Validates one protection coordinator dispatch outcome.
+ * @since 0.1.0 Initial implementation.
+ */
+export const ProtectionCoordinatorDispatchStatusSchema = z.enum( ProtectionCoordinatorDispatchStatus );
+
+/**
+ * Protection coordinator dispatch outcome.
+ * @since 0.1.0 Initial implementation.
+ */
+export type ProtectionCoordinatorDispatchStatus = z.infer<typeof ProtectionCoordinatorDispatchStatusSchema>;
+
+/**
+ * Stable reasons for rejected coordinator operations.
+ * @since 0.1.0 Initial implementation.
+ */
+export const ProtectionCoordinatorFailureReason = {
+	STORAGE_READ_FAILED: 'storage-read-failed',
+	STORAGE_WRITE_FAILED: 'storage-write-failed',
+	INVALID_DURABLE_STATE: 'invalid-durable-state',
+	NOT_INITIALIZED: 'not-initialized',
+	UNKNOWN_SCOPE: 'unknown-scope',
+	INVALID_EVENT: 'invalid-event',
+} as const;
+
+/**
+ * Validates a stable coordinator operation failure reason.
+ * @since 0.1.0 Initial implementation.
+ */
+export const ProtectionCoordinatorFailureReasonSchema = z.enum( ProtectionCoordinatorFailureReason );
+
+/**
+ * Stable coordinator operation failure reason.
+ * @since 0.1.0 Initial implementation.
+ */
+export type ProtectionCoordinatorFailureReason = z.infer<typeof ProtectionCoordinatorFailureReasonSchema>;
+
+/**
+ * Validates explicit observations supplied during coordinator initialization.
+ * @since 0.1.0 Initial implementation.
+ */
+export const ProtectionCoordinatorInitializationInputSchema = z.object( {
+	nowEpochMilliseconds: EpochMillisecondsSchema,
+	readyObservations: z.array( ReadyProtectionStateRestoreObservationSchema ),
+} ).strict();
+
+/**
+ * Explicit observations supplied during coordinator initialization.
+ * @since 0.1.0 Initial implementation.
+ */
+export type ProtectionCoordinatorInitializationInput = z.infer<
+	typeof ProtectionCoordinatorInitializationInputSchema
+>;
+
+/**
+ * Validates an empty coordinator result collection.
+ * @since 0.1.0 Initial implementation.
+ */
+const EmptyProtectionCoordinatorCollectionSchema = z.tuple( [] );
+
+/**
+ * Validates completed coordinator initialization.
+ * @since 0.1.0 Initial implementation.
+ */
+const ReadyProtectionCoordinatorInitializationResultSchema = z.object( {
+	status: z.enum( [ ProtectionCoordinatorInitializationStatus.READY ] ),
+	decisions: z.array( ProtectionDecisionSchema ),
+	facts: EmptyProtectionCoordinatorCollectionSchema,
+	requirements: EmptyProtectionCoordinatorCollectionSchema,
+} ).strict();
+
+/**
+ * Validates initialization with unresolved Ready observations.
+ * @since 0.1.0 Initial implementation.
+ */
+const ReconciliationProtectionCoordinatorInitializationResultSchema = z.object( {
+	status: z.enum( [ ProtectionCoordinatorInitializationStatus.RECONCILIATION_REQUIRED ] ),
+	decisions: z.array( ProtectionDecisionSchema ),
+	facts: EmptyProtectionCoordinatorCollectionSchema,
+	requirements: z.array( ProtectionStateReconciliationRequirementSchema ).min( 1 ),
+} ).strict();
+
+/**
+ * Validates failed coordinator initialization.
+ * @since 0.1.0 Initial implementation.
+ */
+const FailedProtectionCoordinatorInitializationResultSchema = z.object( {
+	status: z.enum( [ ProtectionCoordinatorInitializationStatus.FAILED ] ),
+	reason: z.enum( [
+		ProtectionCoordinatorFailureReason.STORAGE_READ_FAILED,
+		ProtectionCoordinatorFailureReason.STORAGE_WRITE_FAILED,
+		ProtectionCoordinatorFailureReason.INVALID_DURABLE_STATE,
+	] ),
+	decisions: EmptyProtectionCoordinatorCollectionSchema,
+	facts: EmptyProtectionCoordinatorCollectionSchema,
+	requirements: EmptyProtectionCoordinatorCollectionSchema,
+} ).strict();
+
+/**
+ * Validates every protection coordinator initialization result.
+ * @since 0.1.0 Initial implementation.
+ */
+export const ProtectionCoordinatorInitializationResultSchema = z.discriminatedUnion( 'status', [
+	ReadyProtectionCoordinatorInitializationResultSchema,
+	ReconciliationProtectionCoordinatorInitializationResultSchema,
+	FailedProtectionCoordinatorInitializationResultSchema,
+] );
+
+/**
+ * Complete protection coordinator initialization result.
+ * @since 0.1.0 Initial implementation.
+ */
+export type ProtectionCoordinatorInitializationResult = z.infer<
+	typeof ProtectionCoordinatorInitializationResultSchema
+>;
+
+/**
+ * Validates one persisted protection event result.
+ * @since 0.1.0 Initial implementation.
+ */
+const AppliedProtectionCoordinatorDispatchResultSchema = z.object( {
+	status: z.enum( [ ProtectionCoordinatorDispatchStatus.APPLIED ] ),
+	decisions: z.array( ProtectionDecisionSchema ),
+	facts: z.array( ProtectionFactSchema ),
+} ).strict();
+
+/**
+ * Validates one rejected protection event result.
+ * @since 0.1.0 Initial implementation.
+ */
+const RejectedProtectionCoordinatorDispatchResultSchema = z.object( {
+	status: z.enum( [ ProtectionCoordinatorDispatchStatus.REJECTED ] ),
+	reason: z.enum( [
+		ProtectionCoordinatorFailureReason.STORAGE_WRITE_FAILED,
+		ProtectionCoordinatorFailureReason.NOT_INITIALIZED,
+		ProtectionCoordinatorFailureReason.UNKNOWN_SCOPE,
+		ProtectionCoordinatorFailureReason.INVALID_EVENT,
+	] ),
+	decisions: EmptyProtectionCoordinatorCollectionSchema,
+	facts: EmptyProtectionCoordinatorCollectionSchema,
+} ).strict();
+
+/**
+ * Validates every protection coordinator dispatch result.
+ * @since 0.1.0 Initial implementation.
+ */
+export const ProtectionCoordinatorDispatchResultSchema = z.discriminatedUnion( 'status', [
+	AppliedProtectionCoordinatorDispatchResultSchema,
+	RejectedProtectionCoordinatorDispatchResultSchema,
+] );
+
+/**
+ * Complete protection coordinator dispatch result.
+ * @since 0.1.0 Initial implementation.
+ */
+export type ProtectionCoordinatorDispatchResult = z.infer<typeof ProtectionCoordinatorDispatchResultSchema>;
+
+/**
+ * Collects current browser observations and creates one event while coordinator serialization is held.
+ * @return Unknown event value, which may be asynchronous.
+ * @since 0.1.0 Initial implementation.
+ */
+export type PrepareProtectionEvent = () => unknown;
+
+/**
+ * Dependencies used by one protection coordinator instance.
+ * @since 0.1.0 Initial implementation.
+ */
+export interface ProtectionCoordinatorOptions {
+	storage: ProtectionStorageService;
+
+	/**
+	 * Creates a fresh browser-session continuity identifier.
+	 * @return Fresh continuity identifier.
+	 * @since 0.1.0 Initial implementation.
+	 */
+	createSessionContinuityId(): string;
+}
+
+/**
+ * Serialized protection runtime operations.
+ * @since 0.1.0 Initial implementation.
+ */
+export interface ProtectionCoordinator {
+	/**
+	 * Restores and normalizes persisted protection state.
+	 * @param input - Unknown initialization observations.
+	 * @return Validated initialization result after persistence.
+	 * @throws {Error} When input validation or a domain invariant fails unexpectedly.
+	 * @since 0.1.0 Initial implementation.
+	 */
+	initialize( input: unknown ): Promise<ProtectionCoordinatorInitializationResult>;
+
+	/**
+	 * Prepares, applies, and persists one protection event inside the serialized queue.
+	 * @param prepareEvent - Deferred event preparation with current browser observations.
+	 * @return Validated dispatch result after persistence.
+	 * @throws {Error} When event preparation rejects or a domain invariant fails unexpectedly.
+	 * @since 0.1.0 Initial implementation.
+	 */
+	dispatch( prepareEvent: PrepareProtectionEvent ): Promise<ProtectionCoordinatorDispatchResult>;
+}

--- a/apps/extension/src/domains/protection/services/protection-storage/index.test.ts
+++ b/apps/extension/src/domains/protection/services/protection-storage/index.test.ts
@@ -1,0 +1,360 @@
+import { describe, expect, it } from 'vitest';
+import {
+	Mock_StoredProtectionState_Durable,
+	Mock_StoredProtectionState_Session,
+} from '../../types/__fixtures__/stored-protection-state';
+import { StoredProtectionStateSchema } from '../../types/stored-protection-state';
+import {
+	ProtectionStorageKey,
+	createProtectionStorageService,
+} from './index';
+
+/**
+ * Promise whose completion is controlled by a test.
+ */
+class DeferredPromise {
+	readonly promise: Promise<void>;
+
+	private resolver: ( () => void ) | null = null;
+
+	/**
+	 * Creates an unresolved promise.
+	 */
+	constructor() {
+		this.promise = new Promise( ( resolve ) => {
+			this.resolver = resolve;
+		} );
+	}
+
+	/**
+	 * Resolves the controlled promise once.
+	 */
+	resolve(): void {
+		this.resolver?.();
+		this.resolver = null;
+	}
+}
+
+/**
+ * In-memory browser storage area used to observe storage-service behavior.
+ */
+class MemoryProtectionStorageArea {
+	readonly readKeys: string[] = [];
+
+	readonly writtenValues: Record<string, unknown>[] = [];
+
+	readBarrier: Promise<void> | null = null;
+
+	/**
+	 * Creates an in-memory storage area with optional failures and write tracing.
+	 * @param values - Initial stored values.
+	 * @param writeOrder - Shared write-order trace.
+	 * @param label - Area label recorded for each write.
+	 * @param readFailure - Optional read failure.
+	 * @param writeFailure - Optional write failure.
+	 */
+	constructor(
+		private readonly values: Record<string, unknown> = {},
+		private readonly writeOrder: string[] = [],
+		private readonly label = 'storage',
+		private readonly readFailure: Error | null = null,
+		private readonly writeFailure: Error | null = null,
+	) {}
+
+	/**
+	 * Reads one key from the in-memory storage area.
+	 * @param key - Requested storage key.
+	 * @return Matching record or an empty record.
+	 */
+	async get( key: string ): Promise<Record<string, unknown>> {
+		if ( this.readFailure !== null ) {
+			throw this.readFailure;
+		}
+
+		this.readKeys.push( key );
+
+		if ( this.readBarrier !== null ) {
+			await this.readBarrier;
+		}
+
+		return Object.hasOwn( this.values, key ) ? { [ key ]: this.values[ key ] } : {};
+	}
+
+	/**
+	 * Writes values to the in-memory storage area.
+	 * @param values - Values to store.
+	 * @return Promise resolved after the values are stored.
+	 */
+	set( values: Record<string, unknown> ): Promise<void> {
+		this.writeOrder.push( this.label );
+
+		if ( this.writeFailure !== null ) {
+			return Promise.reject( this.writeFailure );
+		}
+
+		this.writtenValues.push( values );
+		Object.assign( this.values, values );
+
+		return Promise.resolve();
+	}
+}
+
+const STORED_PROTECTION_STATE = StoredProtectionStateSchema.parse( {
+	durable: Mock_StoredProtectionState_Durable,
+	session: Mock_StoredProtectionState_Session,
+} );
+
+const TEST_SNAPSHOT_ID = '00000000-0000-4000-8000-000000000001';
+
+/**
+ * Supplies a deterministic storage snapshot identifier.
+ * @return Stable snapshot identifier.
+ */
+function createTestSnapshotId(): string {
+	return TEST_SNAPSHOT_ID;
+}
+
+/**
+ * Wraps one stored document in its storage snapshot envelope.
+ * @param snapshotId - Shared storage snapshot identifier.
+ * @param document - Domain persistence document.
+ * @return Storage snapshot envelope.
+ */
+function createStoredEnvelope( snapshotId: string, document: unknown ): Record<string, unknown> {
+	return { snapshotId, document };
+}
+
+describe( 'protection storage service', () => {
+	it( 'loads durable and session documents from their exact independent keys', async () => {
+		const durableArea = new MemoryProtectionStorageArea( {
+			'tocus.protection.durable.v1': createStoredEnvelope(
+				TEST_SNAPSHOT_ID,
+				STORED_PROTECTION_STATE.durable,
+			),
+		} );
+		const sessionArea = new MemoryProtectionStorageArea( {
+			'tocus.protection.session.v1': createStoredEnvelope(
+				TEST_SNAPSHOT_ID,
+				STORED_PROTECTION_STATE.session,
+			),
+		} );
+		const storage = createProtectionStorageService( {
+			durableArea,
+			sessionArea,
+			createSnapshotId: createTestSnapshotId,
+		} );
+
+		await expect( storage.load() ).resolves.toEqual( STORED_PROTECTION_STATE );
+		expect( durableArea.readKeys ).toEqual( [ 'tocus.protection.durable.v1' ] );
+		expect( sessionArea.readKeys ).toEqual( [ 'tocus.protection.session.v1' ] );
+	} );
+
+	it( 'starts both independent reads before either one resolves', async () => {
+		const readBarrier = new DeferredPromise();
+		const durableArea = new MemoryProtectionStorageArea();
+		const sessionArea = new MemoryProtectionStorageArea();
+
+		durableArea.readBarrier = readBarrier.promise;
+		sessionArea.readBarrier = readBarrier.promise;
+
+		const storage = createProtectionStorageService( {
+			durableArea,
+			sessionArea,
+			createSnapshotId: createTestSnapshotId,
+		} );
+		const loadedState = storage.load();
+
+		expect( durableArea.readKeys ).toEqual( [ ProtectionStorageKey.DURABLE ] );
+		expect( sessionArea.readKeys ).toEqual( [ ProtectionStorageKey.SESSION ] );
+
+		readBarrier.resolve();
+
+		await expect( loadedState ).resolves.toEqual( {} );
+	} );
+
+	it( 'does not recover a session document from a different storage snapshot', async () => {
+		const durableArea = new MemoryProtectionStorageArea( {
+			[ ProtectionStorageKey.DURABLE ]: createStoredEnvelope(
+				'00000000-0000-4000-8000-000000000002',
+				STORED_PROTECTION_STATE.durable,
+			),
+		} );
+		const sessionArea = new MemoryProtectionStorageArea( {
+			[ ProtectionStorageKey.SESSION ]: createStoredEnvelope(
+				'00000000-0000-4000-8000-000000000003',
+				STORED_PROTECTION_STATE.session,
+			),
+		} );
+		const storage = createProtectionStorageService( {
+			durableArea,
+			sessionArea,
+			createSnapshotId: createTestSnapshotId,
+		} );
+
+		await expect( storage.load() ).resolves.toEqual( {
+			durable: STORED_PROTECTION_STATE.durable,
+		} );
+	} );
+
+	it( 'does not recover an orphaned session document without durable proof', async () => {
+		const storage = createProtectionStorageService( {
+			durableArea: new MemoryProtectionStorageArea(),
+			sessionArea: new MemoryProtectionStorageArea( {
+				[ ProtectionStorageKey.SESSION ]: createStoredEnvelope(
+					TEST_SNAPSHOT_ID,
+					STORED_PROTECTION_STATE.session,
+				),
+			} ),
+			createSnapshotId: createTestSnapshotId,
+		} );
+
+		await expect( storage.load() ).resolves.toEqual( {} );
+	} );
+
+	it( 'loads a committed durable document without session continuity', async () => {
+		const storage = createProtectionStorageService( {
+			durableArea: new MemoryProtectionStorageArea( {
+				[ ProtectionStorageKey.DURABLE ]: createStoredEnvelope(
+					TEST_SNAPSHOT_ID,
+					STORED_PROTECTION_STATE.durable,
+				),
+			} ),
+			sessionArea: new MemoryProtectionStorageArea(),
+			createSnapshotId: createTestSnapshotId,
+		} );
+
+		await expect( storage.load() ).resolves.toEqual( {
+			durable: STORED_PROTECTION_STATE.durable,
+		} );
+	} );
+
+	it( 'ignores a malformed session envelope beside valid durable state', async () => {
+		const storage = createProtectionStorageService( {
+			durableArea: new MemoryProtectionStorageArea( {
+				[ ProtectionStorageKey.DURABLE ]: createStoredEnvelope(
+					TEST_SNAPSHOT_ID,
+					STORED_PROTECTION_STATE.durable,
+				),
+			} ),
+			sessionArea: new MemoryProtectionStorageArea( {
+				[ ProtectionStorageKey.SESSION ]: STORED_PROTECTION_STATE.session,
+			} ),
+			createSnapshotId: createTestSnapshotId,
+		} );
+
+		await expect( storage.load() ).resolves.toEqual( {
+			durable: STORED_PROTECTION_STATE.durable,
+		} );
+	} );
+
+	it( 'reports a malformed durable envelope as invalid stored state', async () => {
+		const storage = createProtectionStorageService( {
+			durableArea: new MemoryProtectionStorageArea( {
+				[ ProtectionStorageKey.DURABLE ]: STORED_PROTECTION_STATE.durable,
+			} ),
+			sessionArea: new MemoryProtectionStorageArea( {
+				[ ProtectionStorageKey.SESSION ]: createStoredEnvelope(
+					TEST_SNAPSHOT_ID,
+					STORED_PROTECTION_STATE.session,
+				),
+			} ),
+			createSnapshotId: createTestSnapshotId,
+		} );
+
+		await expect( storage.load() ).resolves.toEqual( { durable: null } );
+	} );
+
+	it( 'keeps missing durable and session documents absent', async () => {
+		const storage = createProtectionStorageService( {
+			durableArea: new MemoryProtectionStorageArea(),
+			sessionArea: new MemoryProtectionStorageArea(),
+			createSnapshotId: createTestSnapshotId,
+		} );
+
+		await expect( storage.load() ).resolves.toEqual( {} );
+	} );
+
+	it( 'writes the session document before the durable document', async () => {
+		const writeOrder: string[] = [];
+		const durableArea = new MemoryProtectionStorageArea( {}, writeOrder, 'durable' );
+		const sessionArea = new MemoryProtectionStorageArea( {}, writeOrder, 'session' );
+		const storage = createProtectionStorageService( {
+			durableArea,
+			sessionArea,
+			createSnapshotId: createTestSnapshotId,
+		} );
+
+		await storage.save( STORED_PROTECTION_STATE );
+
+		expect( writeOrder ).toEqual( [ 'session', 'durable' ] );
+		expect( sessionArea.writtenValues ).toEqual( [ {
+			[ ProtectionStorageKey.SESSION ]: createStoredEnvelope(
+				TEST_SNAPSHOT_ID,
+				STORED_PROTECTION_STATE.session,
+			),
+		} ] );
+		expect( durableArea.writtenValues ).toEqual( [ {
+			[ ProtectionStorageKey.DURABLE ]: createStoredEnvelope(
+				TEST_SNAPSHOT_ID,
+				STORED_PROTECTION_STATE.durable,
+			),
+		} ] );
+	} );
+
+	it( 'exposes immutable exact storage keys', () => {
+		expect( Object.isFrozen( ProtectionStorageKey ) ).toBe( true );
+		expect( ProtectionStorageKey ).toEqual( {
+			DURABLE: 'tocus.protection.durable.v1',
+			SESSION: 'tocus.protection.session.v1',
+		} );
+	} );
+
+	it( 'rejects invalid state before either area is written', async () => {
+		const writeOrder: string[] = [];
+		const storage = createProtectionStorageService( {
+			durableArea: new MemoryProtectionStorageArea( {}, writeOrder, 'durable' ),
+			sessionArea: new MemoryProtectionStorageArea( {}, writeOrder, 'session' ),
+			createSnapshotId: createTestSnapshotId,
+		} );
+
+		await expect( storage.save( { durable: {}, session: {} } ) ).rejects.toThrow();
+		expect( writeOrder ).toEqual( [] );
+	} );
+
+	it( 'propagates a browser read failure', async () => {
+		const readFailure = new Error( 'read failed' );
+		const storage = createProtectionStorageService( {
+			durableArea: new MemoryProtectionStorageArea( {}, [], 'durable', readFailure ),
+			sessionArea: new MemoryProtectionStorageArea(),
+			createSnapshotId: createTestSnapshotId,
+		} );
+
+		await expect( storage.load() ).rejects.toBe( readFailure );
+	} );
+
+	it( 'does not write durable state when the session write fails', async () => {
+		const writeOrder: string[] = [];
+		const writeFailure = new Error( 'session write failed' );
+		const storage = createProtectionStorageService( {
+			durableArea: new MemoryProtectionStorageArea( {}, writeOrder, 'durable' ),
+			sessionArea: new MemoryProtectionStorageArea( {}, writeOrder, 'session', null, writeFailure ),
+			createSnapshotId: createTestSnapshotId,
+		} );
+
+		await expect( storage.save( STORED_PROTECTION_STATE ) ).rejects.toBe( writeFailure );
+		expect( writeOrder ).toEqual( [ 'session' ] );
+	} );
+
+	it( 'propagates a durable write failure after writing session state', async () => {
+		const writeOrder: string[] = [];
+		const writeFailure = new Error( 'durable write failed' );
+		const storage = createProtectionStorageService( {
+			durableArea: new MemoryProtectionStorageArea( {}, writeOrder, 'durable', null, writeFailure ),
+			sessionArea: new MemoryProtectionStorageArea( {}, writeOrder, 'session' ),
+			createSnapshotId: createTestSnapshotId,
+		} );
+
+		await expect( storage.save( STORED_PROTECTION_STATE ) ).rejects.toBe( writeFailure );
+		expect( writeOrder ).toEqual( [ 'session', 'durable' ] );
+	} );
+} );

--- a/apps/extension/src/domains/protection/services/protection-storage/index.ts
+++ b/apps/extension/src/domains/protection/services/protection-storage/index.ts
@@ -1,0 +1,89 @@
+import { StoredProtectionStateSchema } from '../../types/stored-protection-state';
+import {
+	LoadedProtectionStateSchema,
+	ProtectionStorageEnvelopeSchema,
+	ProtectionStorageKey,
+	ProtectionStorageSnapshotIdSchema,
+	type LoadedProtectionState,
+	type ProtectionStorageService,
+	type ProtectionStorageServiceOptions,
+} from './types';
+
+/**
+ * Creates browser-backed durable and session protection persistence.
+ * @param options - Browser storage areas used by the service.
+ * @return Focused protection storage operations.
+ * @since 0.1.0 Initial implementation.
+ */
+export function createProtectionStorageService(
+	options: ProtectionStorageServiceOptions,
+): ProtectionStorageService {
+	/**
+	 * Loads one complete durable and session snapshot for domain parsing.
+	 * @return Compatible domain documents from the latest complete snapshot.
+	 * @throws {Error} When either browser storage read rejects.
+	 * @since 0.1.0 Initial implementation.
+	 */
+	async function load(): Promise<LoadedProtectionState> {
+		const [ durableValues, sessionValues ] = await Promise.all( [
+			options.durableArea.get( ProtectionStorageKey.DURABLE ),
+			options.sessionArea.get( ProtectionStorageKey.SESSION ),
+		] );
+		const hasDurableEnvelope = Object.hasOwn( durableValues, ProtectionStorageKey.DURABLE );
+
+		if ( ! hasDurableEnvelope ) {
+			return LoadedProtectionStateSchema.parse( {} );
+		}
+
+		const durableEnvelope = ProtectionStorageEnvelopeSchema.safeParse(
+			durableValues[ ProtectionStorageKey.DURABLE ],
+		);
+
+		if ( ! durableEnvelope.success ) {
+			return LoadedProtectionStateSchema.parse( { durable: null } );
+		}
+
+		const sessionEnvelope = Object.hasOwn( sessionValues, ProtectionStorageKey.SESSION )
+			? ProtectionStorageEnvelopeSchema.safeParse( sessionValues[ ProtectionStorageKey.SESSION ] )
+			: null;
+
+		return LoadedProtectionStateSchema.parse( {
+			durable: durableEnvelope.data.document,
+			...( sessionEnvelope?.success === true &&
+				sessionEnvelope.data.snapshotId === durableEnvelope.data.snapshotId
+				? { session: sessionEnvelope.data.document }
+				: {} ),
+		} );
+	}
+
+	/**
+	 * Validates and stores session state before durable state.
+	 * @param input - Unknown complete stored-state input.
+	 * @return Promise resolved after both writes complete.
+	 * @throws {Error} When validation fails or either browser storage write rejects.
+	 * @since 0.1.0 Initial implementation.
+	 */
+	async function save( input: unknown ): Promise<void> {
+		const state = StoredProtectionStateSchema.parse( input );
+		const snapshotId = ProtectionStorageSnapshotIdSchema.parse( options.createSnapshotId() );
+		const sessionEnvelope = ProtectionStorageEnvelopeSchema.parse( {
+			snapshotId,
+			document: state.session,
+		} );
+		const durableEnvelope = ProtectionStorageEnvelopeSchema.parse( {
+			snapshotId,
+			document: state.durable,
+		} );
+
+		await options.sessionArea.set( {
+			[ ProtectionStorageKey.SESSION ]: sessionEnvelope,
+		} );
+		await options.durableArea.set( {
+			[ ProtectionStorageKey.DURABLE ]: durableEnvelope,
+		} );
+	}
+
+	return { load, save };
+}
+
+export * from './types';

--- a/apps/extension/src/domains/protection/services/protection-storage/types.ts
+++ b/apps/extension/src/domains/protection/services/protection-storage/types.ts
@@ -1,0 +1,113 @@
+import { z } from 'zod';
+
+/**
+ * Stable keys for durable and session protection documents.
+ * @since 0.1.0 Initial implementation.
+ */
+export const ProtectionStorageKey = Object.freeze( {
+	DURABLE: 'tocus.protection.durable.v1',
+	SESSION: 'tocus.protection.session.v1',
+} as const );
+
+/**
+ * Validates one identifier shared by a complete durable and session snapshot.
+ * @since 0.1.0 Initial implementation.
+ */
+export const ProtectionStorageSnapshotIdSchema = z.uuid().brand<'ProtectionStorageSnapshotId'>();
+
+/**
+ * Identifier shared by a complete durable and session snapshot.
+ * @since 0.1.0 Initial implementation.
+ */
+export type ProtectionStorageSnapshotId = z.infer<typeof ProtectionStorageSnapshotIdSchema>;
+
+/**
+ * Validates one domain document wrapped with its shared storage snapshot identifier.
+ * @since 0.1.0 Initial implementation.
+ */
+export const ProtectionStorageEnvelopeSchema = z.object( {
+	snapshotId: ProtectionStorageSnapshotIdSchema,
+	document: z.unknown(),
+} ).strict();
+
+/**
+ * Domain document wrapped with its shared storage snapshot identifier.
+ * @since 0.1.0 Initial implementation.
+ */
+export type ProtectionStorageEnvelope = z.infer<typeof ProtectionStorageEnvelopeSchema>;
+
+/**
+ * Validates independently loaded durable and session protection documents.
+ * @since 0.1.0 Initial implementation.
+ */
+export const LoadedProtectionStateSchema = z.object( {
+	durable: z.unknown().optional(),
+	session: z.unknown().optional(),
+} ).strict();
+
+/**
+ * Independently loaded durable and session protection documents.
+ * @since 0.1.0 Initial implementation.
+ */
+export type LoadedProtectionState = z.infer<typeof LoadedProtectionStateSchema>;
+
+/**
+ * Minimal browser storage-area operations used by protection persistence.
+ * @since 0.1.0 Initial implementation.
+ */
+export interface ProtectionStorageArea {
+	/**
+	 * Reads one storage key.
+	 * @param key - Requested storage key.
+	 * @return Stored values indexed by key.
+	 * @since 0.1.0 Initial implementation.
+	 */
+	get( key: string ): Promise<Record<string, unknown>>;
+
+	/**
+	 * Writes values indexed by storage key.
+	 * @param values - Values to store.
+	 * @return Promise resolved after the write completes.
+	 * @since 0.1.0 Initial implementation.
+	 */
+	set( values: Record<string, unknown> ): Promise<void>;
+}
+
+/**
+ * Browser storage areas used by protection persistence.
+ * @since 0.1.0 Initial implementation.
+ */
+export interface ProtectionStorageServiceOptions {
+	durableArea: ProtectionStorageArea;
+	sessionArea: ProtectionStorageArea;
+
+	/**
+	 * Creates a fresh storage snapshot identifier.
+	 * @return Fresh snapshot identifier.
+	 * @since 0.1.0 Initial implementation.
+	 */
+	createSnapshotId(): string;
+}
+
+/**
+ * Browser-backed protection persistence operations.
+ * @since 0.1.0 Initial implementation.
+ */
+export interface ProtectionStorageService {
+	/**
+	 * Loads durable and session protection documents independently.
+	 * @return Loaded unknown documents for domain parsing.
+	 * @throws {Error} When either browser storage read rejects.
+	 * @since 0.1.0 Initial implementation.
+	 */
+	load(): Promise<LoadedProtectionState>;
+
+	/**
+	 * Validates and stores durable and session protection documents.
+	 * @param input - Unknown complete stored-state input.
+	 * @return Promise resolved after both writes complete.
+	 * @throws {Error} When validation fails or either browser storage write rejects.
+	 * @since 0.1.0 Initial implementation.
+	 */
+	save( input: unknown ): Promise<void>;
+}

--- a/apps/extension/src/entrypoints/background/index.test.ts
+++ b/apps/extension/src/entrypoints/background/index.test.ts
@@ -1,0 +1,90 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { fakeBrowser } from 'wxt/testing/fake-browser';
+import { TestInstant } from '../../domains/protection/types/__fixtures__/protection-event';
+
+const backgroundMocks = vi.hoisted( () => ( {
+	createProtectionCoordinator: vi.fn(),
+	createProtectionStorageService: vi.fn(),
+	initialize: vi.fn(),
+} ) );
+
+vi.mock( 'wxt/browser', async () => {
+	const { fakeBrowser: mockedBrowser } = await import( 'wxt/testing/fake-browser' );
+
+	return { browser: mockedBrowser };
+} );
+
+vi.mock( '../../domains/protection', () => ( {
+	createProtectionCoordinator: backgroundMocks.createProtectionCoordinator,
+	createProtectionStorageService: backgroundMocks.createProtectionStorageService,
+} ) );
+
+import backgroundDefinition from './index';
+
+describe( 'protection background entrypoint', () => {
+	beforeEach( () => {
+		fakeBrowser.reset();
+		vi.clearAllMocks();
+		vi.spyOn( Date, 'now' ).mockReturnValue( TestInstant );
+	} );
+
+	afterEach( () => {
+		vi.restoreAllMocks();
+	} );
+
+	it( 'starts one coordinator with local and session storage', () => {
+		const storage = {
+			load: vi.fn(),
+			save: vi.fn(),
+		};
+		const coordinator = {
+			dispatch: vi.fn(),
+			initialize: backgroundMocks.initialize,
+		};
+
+		backgroundMocks.createProtectionStorageService.mockReturnValue( storage );
+		backgroundMocks.createProtectionCoordinator.mockReturnValue( coordinator );
+
+		const runBackground: () => unknown = backgroundDefinition.main.bind( backgroundDefinition );
+		const mainResult = runBackground();
+
+		expect( mainResult ).toBeUndefined();
+		expect( backgroundMocks.createProtectionStorageService ).toHaveBeenCalledOnce();
+		expect( backgroundMocks.createProtectionCoordinator ).toHaveBeenCalledOnce();
+
+		const storageOptions: unknown = backgroundMocks.createProtectionStorageService.mock.calls[ 0 ]?.[ 0 ];
+
+		if (
+			typeof storageOptions !== 'object' ||
+			storageOptions === null ||
+			! ( 'durableArea' in storageOptions ) ||
+			! ( 'sessionArea' in storageOptions ) ||
+			! ( 'createSnapshotId' in storageOptions )
+		) {
+			throw new TypeError( 'Expected complete protection storage options.' );
+		}
+
+		expect( storageOptions.durableArea ).toBe( fakeBrowser.storage.local );
+		expect( storageOptions.sessionArea ).toBe( fakeBrowser.storage.session );
+		expect( typeof storageOptions.createSnapshotId ).toBe( 'function' );
+
+		const coordinatorOptions: unknown = backgroundMocks.createProtectionCoordinator.mock.calls[ 0 ]?.[ 0 ];
+
+		if (
+			typeof coordinatorOptions !== 'object' ||
+			coordinatorOptions === null ||
+			! ( 'storage' in coordinatorOptions ) ||
+			! ( 'createSessionContinuityId' in coordinatorOptions )
+		) {
+			throw new TypeError( 'Expected complete protection coordinator options.' );
+		}
+
+		expect( coordinatorOptions.storage ).toBe( storage );
+		expect( typeof coordinatorOptions.createSessionContinuityId ).toBe( 'function' );
+		expect( backgroundMocks.initialize ).toHaveBeenCalledOnce();
+		expect( backgroundMocks.initialize ).toHaveBeenCalledWith( {
+			nowEpochMilliseconds: TestInstant,
+			readyObservations: [],
+		} );
+	} );
+} );

--- a/apps/extension/src/entrypoints/background/index.ts
+++ b/apps/extension/src/entrypoints/background/index.ts
@@ -1,0 +1,27 @@
+import { browser } from 'wxt/browser';
+import { defineBackground } from 'wxt/utils/define-background';
+import {
+	createProtectionCoordinator,
+	createProtectionStorageService,
+} from '../../domains/protection';
+
+/**
+ * Starts browser-backed protection-state restoration for each background runtime.
+ * @since 0.1.0 Initial implementation.
+ */
+export default defineBackground( () => {
+	const storage = createProtectionStorageService( {
+		durableArea: browser.storage.local,
+		sessionArea: browser.storage.session,
+		createSnapshotId: crypto.randomUUID.bind( crypto ),
+	} );
+	const coordinator = createProtectionCoordinator( {
+		storage,
+		createSessionContinuityId: crypto.randomUUID.bind( crypto ),
+	} );
+
+	void coordinator.initialize( {
+		nowEpochMilliseconds: Date.now(),
+		readyObservations: [],
+	} );
+} );

--- a/apps/extension/tests/build/manifest.test.ts
+++ b/apps/extension/tests/build/manifest.test.ts
@@ -53,11 +53,11 @@ async function expectPopupComposition( outputUrl: URL ): Promise<void> {
 }
 
 /**
- * Verifies that a generated manifest requests no broad browser permissions.
+ * Verifies that a generated manifest requests only local extension storage.
  * @param manifest - Parsed generated manifest.
  */
-function expectNoBroadPermissions( manifest: unknown ): void {
-	expect( manifest ).not.toHaveProperty( 'permissions' );
+function expectNarrowStoragePermission( manifest: unknown ): void {
+	expect( manifest ).toHaveProperty( 'permissions', [ 'storage' ] );
 	expect( manifest ).not.toHaveProperty( 'optional_permissions' );
 	expect( manifest ).not.toHaveProperty( 'host_permissions' );
 	expect( manifest ).not.toHaveProperty( 'optional_host_permissions' );
@@ -93,37 +93,39 @@ function expectValidExtensionVersion( manifest: unknown ): void {
 }
 
 describe( 'extension build manifest', () => {
-	test( 'produces a minimal Chrome popup manifest', async () => {
+	test( 'produces a minimal Chrome extension manifest', async () => {
 		const manifest = await readManifest( chromeManifestUrl );
 
 		expect( manifest ).toMatchObject( {
 			manifest_version: 3,
 			name: 'TOCus',
+			minimum_chrome_version: '102',
 			action: { default_popup: 'popup.html' },
+			background: { service_worker: 'background.js' },
 		} );
-		expect( manifest ).not.toHaveProperty( 'background' );
 		expect( manifest ).not.toHaveProperty( 'browser_specific_settings' );
-		expectNoBroadPermissions( manifest );
+		expectNarrowStoragePermission( manifest );
 		expectValidExtensionVersion( manifest );
 	} );
 
-	test( 'produces a minimal Firefox popup manifest with an explicit no-data declaration', async () => {
+	test( 'produces a minimal Firefox extension manifest with an explicit no-data declaration', async () => {
 		const manifest = await readManifest( firefoxManifestUrl );
 
 		expect( manifest ).toMatchObject( {
 			manifest_version: 2,
 			name: 'TOCus',
 			browser_action: { default_popup: 'popup.html' },
+			background: { scripts: [ 'background.js' ] },
 			browser_specific_settings: {
 				gecko: {
 					id: 'tocus@agustinbarrientos.github.io',
+					strict_min_version: '115.0',
 					data_collection_permissions: { required: [ 'none' ] },
 				},
 			},
 		} );
-		expect( manifest ).not.toHaveProperty( 'background' );
 		expect( manifest ).not.toHaveProperty( 'browser_specific_settings.gecko.data_collection_permissions.optional' );
-		expectNoBroadPermissions( manifest );
+		expectNarrowStoragePermission( manifest );
 		expectValidExtensionVersion( manifest );
 	} );
 

--- a/apps/extension/wxt.config.ts
+++ b/apps/extension/wxt.config.ts
@@ -18,11 +18,14 @@ export default defineConfig( {
 	manifest: ( context ) => ( {
 		name: 'TOCus',
 		description: 'A gentle pause before distracting websites, designed to help you return to your intentions.',
+		permissions: [ 'storage' ],
+		...( context.browser === 'chrome' ? { minimum_chrome_version: '102' } : {} ),
 		...( context.browser === 'firefox'
 			? {
 				browser_specific_settings: {
 					gecko: {
 						id: 'tocus@agustinbarrientos.github.io',
+						strict_min_version: '115.0',
 						data_collection_permissions: { required: [ 'none' ] },
 					},
 				},


### PR DESCRIPTION
## Summary

- Add a serialized protection coordinator that restores local state and persists transitions before returning decisions or facts
- Pair session and durable storage writes with snapshot identifiers so partial writes cannot recover uncommitted session state
- Keep allowance-expiry candidate collection inside the shared queue and return typed rejections for invalid events or unknown scopes
- Start restoration from a synchronous background lifecycle with only the storage permission and compatible browser version floors

## Why

TOCus needs browser-backed runtime state before navigation observers can safely use the protection engine without losing updates or treating partial storage writes as completed transitions.

## Validation

- [x] `pnpm check`
- [x] Unit tests passed: 1,141 with 100% statement, branch, function, and line coverage
- [x] Build-contract tests passed: 8
- [x] Chromium component and accessibility tests passed: 7 with 100% coverage
- [x] Chrome and Firefox production builds passed

## Screenshots or recordings

Not applicable. This change adds background coordination and local persistence without changing the visible interface.

## Privacy, accessibility, and wellbeing

- [x] No account, TOCus server, telemetry or product analytics, browsing-history analysis, or core-operation network request was introduced
- [x] Any browser permission or local storage change is narrowly scoped and explained
- [x] User-facing copy is accessible, gentle, non-judgmental, and non-clinical
- [x] Accessibility impact was considered

## Checklist

- [x] The change is focused and avoids unrelated refactors
- [x] Behavioral changes were developed test-first, and tests or documentation were updated where needed
- [x] No disposable build output, coverage, reports, or caches are included; any visual baselines are intentional test fixtures
- [x] Authored prose, comments, and commit-message paragraphs are not hard-wrapped mid-sentence, and authored files are ASCII-only
- [x] No secrets or personal browsing data are included